### PR TITLE
Change authors to object, with ids

### DIFF
--- a/lib/fake-feed.js
+++ b/lib/fake-feed.js
@@ -13,17 +13,21 @@ function getRandomDate(start, end) {
 
 function createRandomItem (i, sort, req) {
   let obj = {}
-  const authors = []
+  let authors = []
   let count = Math.floor(Math.random() * 6) + 1
   while(count--) {
-    authors.push(lorem({count: 2, units: 'words', format: 'plain'}))
+    let author = {
+      name: lorem({count: 2, units: 'words', format: 'plain'}),
+      id: Math.floor(Math.random()*100000) + '-' + getRandomString()
+    }
+    authors.push(author)
   }
-
+  
   const imgNo = Math.floor(Math.random()* 3) + 1
   obj = {
     id: Math.floor(Math.random()*100000) + '-' + getRandomString(),
     title: lorem({count: 2, units: 'words', format: 'plain'}),
-    authors: authors,
+    authors,
     description: lorem({count: 20, units: 'words', format: 'plain'}),
     journal: lorem({count: 3, units: 'words', format: 'plain'}),
     photo: `http://${req.get('host')}/image_${imgNo}.jpg`,


### PR DESCRIPTION
It made more sense to have the authors as an object, with an id and a name, so that they can be consumed as entities by the api.

(p.s. I did this work during the day! Just pushing it up now)